### PR TITLE
fix an issue where none labeled nodes would fail

### DIFF
--- a/phylorank/outliers.py
+++ b/phylorank/outliers.py
@@ -68,7 +68,7 @@ class Outliers(AbstractPlot):
 
     def __init__(self, dpi=96, output_dir=None):
         """Initialize."""
-        
+
         self.logger = logging.getLogger()
 
         Options = namedtuple('Options', 'width height tick_font_size label_font_size dpi')
@@ -79,12 +79,12 @@ class Outliers(AbstractPlot):
         self.poly_color = (89.0/255,89.0/255,89.0/255)
         self.near_mono_color = (255.0/255,188.0/255,121.0/255)
         self.mono_color = (95.0/255,158.0/255,209.0/255)
-        
+
         self.median_color = (0.0/255,107.0/255,164.0/255)
 
         self.dpi = dpi
         self.output_dir = output_dir
-        
+
     def root_with_outgroup(self, input_tree, taxonomy, outgroup_taxa):
         """Reroot the tree using the given outgroup.
 
@@ -96,15 +96,15 @@ class Outliers(AbstractPlot):
           Taxonomy for taxa.
         outgroup_taxa : str
           Desired outgroup.
-          
+
         Returns
         -------
         Dendropy Tree
             Deep-copy of original tree rerooted on outgroup.
         """
-        
+
         new_tree = input_tree.clone()
-        
+
         outgroup = set()
         for genome_id, taxa in taxonomy.items():
             if outgroup_taxa in taxa:
@@ -124,13 +124,13 @@ class Outliers(AbstractPlot):
             self.logger.warning('No outgroup taxa identified in the tree.')
             self.logger.warning('Tree was not rerooted.')
             sys.exit(0)
-            
+
         # There is a complication here. We wish to find the MRCA of the outgroup
         # taxa. Finding the MRCA requires a rooted tree and we have no guarantee
         # that the tree isn't currently rooted within the outgroup clade. There is
         # also no way to identify a node that is guaranteed to be outside the outgroup
         # clade. As such, the tree is randomly rooted on a leaf node not in the outgroup.
-        # This random rerooting is performed until the MRCA does not spans all taxa in 
+        # This random rerooting is performed until the MRCA does not spans all taxa in
         # the tree.
 
         leaves_in_tree = sum([1 for _ in new_tree.leaf_node_iter()])
@@ -162,12 +162,12 @@ class Outliers(AbstractPlot):
             new_tree.reroot_at_edge(mrca.edge,
                                 length1=0.5 * mrca.edge_length,
                                 length2=0.5 * mrca.edge_length)
-        
+
         return new_tree
 
-    def _distribution_plot(self, 
-                            rel_dists, 
-                            taxa_for_dist_inference, 
+    def _distribution_plot(self,
+                            rel_dists,
+                            taxa_for_dist_inference,
                             highlight_polyphyly,
                             highlight_taxa,
                             distribution_table,
@@ -199,7 +199,7 @@ class Outliers(AbstractPlot):
             v = [dist for taxa, dist in rel_dists[rank].items() if taxa in taxa_for_dist_inference]
             if len(v) == 0:
                 continue
-                
+
             p10, p50, p90 = np_percentile(v, [10, 50, 90])
             ax.plot((p50, p50), (i, i + 0.5), c=self.median_color, lw=2, zorder=2)
 
@@ -224,7 +224,7 @@ class Outliers(AbstractPlot):
             else:
                 rank_label = Taxonomy.rank_labels[rank]
             rank_labels.append(rank_label.capitalize()  + ' ({:,})'.format(len(rel_dists[rank])))
-            
+
             mono = []
             poly = []
             nearly_mono = []
@@ -233,7 +233,7 @@ class Outliers(AbstractPlot):
                 y.append(i)
                 labels.append(clade_label)
 
-                
+
                 if ((highlight_polyphyly and fmeasure[clade_label] < fmeasure_mono) or clade_label in highlight_taxa):
                     c.append(self.poly_color)
                     poly.append(dist)
@@ -243,7 +243,7 @@ class Outliers(AbstractPlot):
                 else:
                     c.append(self.mono_color)
                     mono.append(dist)
-            
+
                 # report results
                 v = [clade_label, dist]
                 if i in percentiles:
@@ -253,9 +253,9 @@ class Outliers(AbstractPlot):
                 else:
                     percentile_outlier = 'Insufficent data to calculate percentiles'
                     v += [-1,-1,-1] + [str(percentile_outlier)]
-                
+
                 fout.write('%s\t%.2f\t%.2f\t%.2f\t%.2f\t%s\n' % tuple(v))
-        
+
             # histogram for each rank
             binwidth = 0.025
             bins = np_arange(0, 1.0 + binwidth, binwidth)
@@ -264,11 +264,11 @@ class Outliers(AbstractPlot):
             num_taxa = len(mono) + len(poly) + len(nearly_mono)
             if num_taxa == 0:
                 break
-            
+
             mono = np_array(mono)
             nearly_mono = np_array(nearly_mono)
             poly = np_array(poly)
-            
+
             bottom_mono = 0
             if len(mono) > 0:
                 bottom_mono, b, p = ax.hist(mono, bins=bins,
@@ -278,7 +278,7 @@ class Outliers(AbstractPlot):
                           bottom=i,
                           lw=0,
                           zorder=0)
-                      
+
             bottom_nearly_mono = 0
             if len(nearly_mono) > 0:
                 bottom_nearly_mono, b, p = ax.hist(nearly_mono, bins=bins,
@@ -300,10 +300,10 @@ class Outliers(AbstractPlot):
         fout.close()
 
         # overlay scatter plot elements
-        scatter = ax.scatter(x, y, 
-                                alpha=0.5, 
-                                s=48, 
-                                c=c, 
+        scatter = ax.scatter(x, y,
+                                alpha=0.5,
+                                s=48,
+                                c=c,
                                 zorder=1,
                                 lw=1,
                                 edgecolors='black')
@@ -332,7 +332,7 @@ class Outliers(AbstractPlot):
         self.fig.savefig(plot_file, dpi=self.dpi)
         self.fig.savefig(plot_file.replace('.png', '.svg'), dpi=self.dpi)
 
-    def _median_outlier_file(self, 
+    def _median_outlier_file(self,
                                 rel_dists,
                                 taxa_for_dist_inference,
                                 gtdb_parent_ranks,
@@ -359,9 +359,9 @@ class Outliers(AbstractPlot):
             v = [dist for taxa, dist in d.items() if taxa in taxa_for_dist_inference]
             if len(v) == 0:
                 continue
-                
+
             median_rel_dist[rank] = np_median(v)
-            
+
         fout_rank = open(median_rank_file, 'w')
         median_str = []
         for rank in sorted(median_rel_dist.keys()):
@@ -375,7 +375,7 @@ class Outliers(AbstractPlot):
 
         fout = open(output_file, 'w')
         fout.write('Taxa\tGTDB taxonomy\tMedian distance\tMean difference\tClosest rank\tClassification\n')
-            
+
         for i, rank in enumerate(sorted(rel_dists.keys())):
             for clade_label, dist in rel_dists[rank].items():
                 if rank in median_rel_dist:
@@ -411,27 +411,27 @@ class Outliers(AbstractPlot):
                                                                    'NA',
                                                                    'Insufficent data to calcualte median for rank.'))
         fout.close()
-        
+
     def taxa_median_rd(self, phylum_rel_dists):
         """Calculate the median relative divergence for each taxon.
-        
+
         Parameters
         ----------
         phylum_rel_dists: phylum_rel_dists[phylum][rank_index][taxon] -> relative divergences
-            Relative divergence of taxon at each rank for different phylum-level rootings.    
+            Relative divergence of taxon at each rank for different phylum-level rootings.
         """
-        
+
         medians_for_taxa = defaultdict(lambda: defaultdict(list))
         for p in phylum_rel_dists:
             for rank, d in phylum_rel_dists[p].items():
                 for taxon, dist in d.items():
                     medians_for_taxa[rank][taxon].append(dist)
-                    
+
         return medians_for_taxa
-        
+
     def rank_median_rd(self, phylum_rel_dists, taxa_for_dist_inference):
         """Calculate median relative divergence for each rank.
-        
+
         Parameters
         ----------
         phylum_rel_dists: phylum_rel_dists[phylum][rank_index][taxon] -> relative divergences
@@ -439,21 +439,21 @@ class Outliers(AbstractPlot):
         taxa_for_dist_inference : iterable
             Taxa to considered when inferring distributions.
         """
-        
+
         medians_for_taxa = self.taxa_median_rd(phylum_rel_dists)
-    
+
         median_for_rank = {}
         for i, rank in enumerate(sorted(medians_for_taxa.keys())):
                 v = [np_median(dists) for taxon, dists in medians_for_taxa[rank].items() if taxon in taxa_for_dist_inference]
-                
+
                 if v:
                     median_for_rank[rank] = np_median(v)
-                
+
         return median_for_rank
-        
-    def _distribution_summary_plot(self, 
-                                    phylum_rel_dists, 
-                                    taxa_for_dist_inference, 
+
+    def _distribution_summary_plot(self,
+                                    phylum_rel_dists,
+                                    taxa_for_dist_inference,
                                     highlight_polyphyly,
                                     highlight_taxa,
                                     fmeasure,
@@ -485,17 +485,17 @@ class Outliers(AbstractPlot):
             if not v:
                 # not taxa at rank suitable for creating classification boundaries
                 continue
-            
+
             p10, p50, p90 = np_percentile(v, [10, 50, 90])
             ax.plot((p50, p50), (i, i + 0.5), c=self.median_color, lw=2, zorder=2)
 
             for b in [-0.1, 0.1]:
                 boundary = p50 + b
                 if boundary < 1.0 and boundary > 0.0:
-                    ax.plot((boundary, boundary), 
-                                (i, i + 0.5), 
-                                c=(0.0, 0.0, 0.0), 
-                                lw=2, 
+                    ax.plot((boundary, boundary),
+                                (i, i + 0.5),
+                                c=(0.0, 0.0, 0.0),
+                                lw=2,
                                 zorder=2)
 
             percentiles[i] = [p10, p50, p90]
@@ -565,15 +565,15 @@ class Outliers(AbstractPlot):
                           bottom=i + mono_bottom + near_mono_bottom,
                           lw=0,
                           zorder=0)
-                          
-        scatter = ax.scatter(x, y, 
-                                alpha=0.5, 
-                                s=48, 
-                                c=c, 
+
+        scatter = ax.scatter(x, y,
+                                alpha=0.5,
+                                s=48,
+                                c=c,
                                 zorder=1,
                                 lw=1,
                                 edgecolors='black')
-        
+
         # set plot elements
         ax.grid(color=(0.8, 0.8, 0.8), linestyle='dashed')
 
@@ -621,10 +621,10 @@ class Outliers(AbstractPlot):
         verbose_table : boolean
             Print additional columns in output table.
         """
-        
+
         # determine median relative distance for each taxa
         medians_for_taxa = self.taxa_median_rd(phylum_rel_dists)
-        
+
         # determine median relative distance for each rank
         median_for_rank = self.rank_median_rd(phylum_rel_dists, taxa_for_dist_inference)
 
@@ -634,7 +634,7 @@ class Outliers(AbstractPlot):
             median_str.append('"' + Taxonomy.rank_labels[rank] + '":' + str(median_for_rank[rank]))
         fout_rank.write('{' + ','.join(median_str) + '}\n')
         fout_rank.close()
-            
+
         fout = open(outlier_table, 'w')
         if verbose_table:
             fout.write('Taxa\tGTDB taxonomy\tMedian distance')
@@ -642,7 +642,7 @@ class Outliers(AbstractPlot):
             fout.write('\tClosest rank\tClassifciation\n')
         else:
             fout.write('Taxa\tGTDB taxonomy\tMedian distance\tMedian difference\tClosest rank\tClassification\n')
-        
+
         for rank in sorted(median_for_rank.keys()):
             for clade_label, dists in medians_for_taxa[rank].items():
                 dists = np_array(dists)
@@ -686,7 +686,7 @@ class Outliers(AbstractPlot):
 
     def rd_fixed_root(self, tree, taxa_for_dist_inference):
         """Scale tree and calculate relative divergence over a single fixed root.
-        
+
         Parameters
         ----------
         tree : Tree
@@ -694,22 +694,22 @@ class Outliers(AbstractPlot):
         taxa_for_dist_inference : set
           Taxa to use for inference relative divergence distributions.
         """
-        
+
         # calculate relative distance to taxa
         rd = RelativeDistance()
         rel_dists = rd.rel_dist_to_named_clades(tree)
-        
+
         # create scaled tree
         rd.decorate_rel_dist(tree)
         for n in tree.preorder_node_iter(lambda n: n != tree.seed_node):
             rd_to_parent = n.rel_dist - n.parent_node.rel_dist
             n.edge_length = rd_to_parent
-        
+
         return rel_dists
-        
+
     def mblet(self, tree, taxa_for_dist_inference):
         """Scale tree and calculate mean branch length to extent taxa.
-        
+
         Parameters
         ----------
         tree : Tree
@@ -717,25 +717,25 @@ class Outliers(AbstractPlot):
         taxa_for_dist_inference : set
           Taxa to use for inference MBLET distributions.
         """
-        
+
         # calculate relative distance to taxa
         rd = RelativeDistance()
         rel_dists = rd.rel_dist_to_named_clades(tree, mblet=True)
-        
+
         # create scaled tree
         rd.decorate_rel_dist(tree)
         for n in tree.preorder_node_iter(lambda n: n != tree.seed_node):
             rd_to_parent = n.rel_dist - n.parent_node.rel_dist
             n.edge_length = rd_to_parent
-        
+
         return rel_dists
 
-    def median_rd_over_phyla(self, 
-                                tree, 
+    def median_rd_over_phyla(self,
+                                tree,
                                 taxa_for_dist_inference,
                                 taxonomy=None):
         """Calculate the median relative divergence over all phyla rootings.
-        
+
         Parameters
         ----------
         tree : Tree
@@ -743,26 +743,26 @@ class Outliers(AbstractPlot):
         taxa_for_dist_inference : set
           Taxa to use for inference relative divergence distributions.
         """
-        
+
         # read taxonomy from tree
         if not taxonomy:
-            taxonomy = Taxonomy().read_from_tree(tree, 
+            taxonomy = Taxonomy().read_from_tree(tree,
                                                     warnings=False)
-    
+
         # get list of phyla level lineages
         all_phyla = get_phyla_lineages(tree)
         self.logger.info('Identified %d phyla.' % len(all_phyla))
-        
+
         phyla = [p for p in all_phyla if p in taxa_for_dist_inference]
         self.logger.info('Using %d phyla as rootings for inferring distributions.' % len(phyla))
         if len(phyla) < 2:
             self.logger.error('Rescaling requires at least 2 valid phyla.')
             sys.exit(-1)
-            
+
         # give each node a unique id
         for i, n in enumerate(tree.preorder_node_iter()):
             n.id = i
-    
+
         # calculate relative divergence for tree rooted on each phylum
         phylum_rel_dists = {}
         rel_node_dists = defaultdict(list)
@@ -770,9 +770,9 @@ class Outliers(AbstractPlot):
         for p in phyla:
             phylum = p.replace('p__', '').replace(' ', '_').lower()
             self.logger.info('Calculating information with rooting on %s.' % phylum.capitalize())
-            
+
             cur_tree = self.root_with_outgroup(tree, taxonomy, p)
-            
+
             # calculate relative distance to taxa
             rel_dists = rd.rel_dist_to_named_clades(cur_tree)
             rel_dists.pop(0, None) # remove results for Domain
@@ -787,10 +787,10 @@ class Outliers(AbstractPlot):
                     rel_dists[r].pop(t, None)
 
             phylum_rel_dists[phylum] = rel_dists
-            
+
             # calculate relative distance to all nodes
             rd.decorate_rel_dist(cur_tree)
-            
+
             # determine which lineages represents the 'ingroup'
             ingroup_subtree = None
             for c in cur_tree.seed_node.child_node_iter():
@@ -798,16 +798,16 @@ class Outliers(AbstractPlot):
                 if not taxon_name or p not in taxon_name:
                     ingroup_subtree = c
                     break
-            
+
             # do a preorder traversal of 'ingroup' and record relative divergence to nodes
-            for n in ingroup_subtree.preorder_iter():                        
+            for n in ingroup_subtree.preorder_iter():
                 rel_node_dists[n.id].append(n.rel_dist)
-                                                           
+
         return phylum_rel_dists, rel_node_dists
-        
+
     def _write_rd(self, tree, output_rd_file):
         """Write out relative divergences for each node."""
-        
+
         fout = open(output_rd_file, 'w')
         for n in tree.preorder_node_iter():
             if n.is_leaf():
@@ -816,9 +816,9 @@ class Outliers(AbstractPlot):
                 # get left and right taxa that define this node
                 taxa = list(n.preorder_iter(lambda n: n.is_leaf()))
                 fout.write('%s|%s\t%f\n' % (taxa[0].taxon.label, taxa[-1].taxon.label, n.rel_dist))
-                
+
         fout.close()
-        
+
     def _write_rd_tree(self, tree, rel_node_dists, output_tree):
         """Write out tree with RED specified at each internal node."""
 
@@ -827,35 +827,39 @@ class Outliers(AbstractPlot):
                 red = 0
             else:
                 red = np_median(rel_node_dists[node_id])
-                
+
+            red_str = "|RED={:.3f}".format(red)
             if n.is_leaf():
-                n.taxon.label += "|RED={:.3f}".format(red)
+                n.taxon.label += red_str
             else:
-                n.label += "|RED={:.3f}".format(red)
-        
-        tree.write_to_path(output_tree, 
-                            schema='newick', 
-                            suppress_rooting=True, 
+                if n.label:
+                    n.label += red_str
+                else:
+                    n.label = red_str
+
+        tree.write_to_path(output_tree,
+                            schema='newick',
+                            suppress_rooting=True,
                             unquoted_underscores=True)
-        
+
     def read_fmeasure(self, fmeasure_table):
         """Read table with F-measure for taxa."""
-        
+
         fmeasure = {}
         with open(fmeasure_table) as f:
             f.readline()
-            
+
             for line in f:
                 line_split = line.strip().split('\t')
-                
+
                 taxa = line_split[0]
                 fmeasure[taxa] = float(line_split[2])
-                
+
         return fmeasure
-        
-    def run(self, 
-                input_tree, 
-                taxonomy_file, 
+
+    def run(self,
+                input_tree,
+                taxonomy_file,
                 viral,
                 plot_taxa_file,
                 plot_dist_taxa_only,
@@ -864,7 +868,7 @@ class Outliers(AbstractPlot):
                 highlight_taxa_file,
                 trusted_taxa_file,
                 fixed_root,
-                min_children, 
+                min_children,
                 min_support,
                 mblet,
                 fmeasure_table,
@@ -881,7 +885,7 @@ class Outliers(AbstractPlot):
           File with taxonomy strings for each taxa.
         plot_taxa_file : str
           File specifying taxa to plot. Set to None to consider all taxa.
-        plot_dist_taxa_only : boolean    
+        plot_dist_taxa_only : boolean
           Only plot the taxa used to infer distribution.
         plot_domain : boolean
           Plot domain rank.
@@ -896,12 +900,12 @@ class Outliers(AbstractPlot):
         verbose_table : boolean
           Print additional columns in output table.
         """
-        
+
         # read tree
         self.logger.info('Reading tree.')
-        tree = dendropy.Tree.get_from_path(input_tree, 
-                                            schema='newick', 
-                                            rooting='force-rooted', 
+        tree = dendropy.Tree.get_from_path(input_tree,
+                                            schema='newick',
+                                            rooting='force-rooted',
                                             preserve_underscores=True)
 
         orig_tree = tree.clone(depth=1)
@@ -910,7 +914,7 @@ class Outliers(AbstractPlot):
         # pull taxonomy from tree and file
         self.logger.info('Reading taxonomy.')
         taxonomy = Taxonomy().read(taxonomy_file)
-        
+
         if viral:
             self.logger.info('Translating viral prefixes.')
             taxonomy = translate_viral_taxonomy(taxonomy)
@@ -921,24 +925,24 @@ class Outliers(AbstractPlot):
             self.logger.info('Reading taxonomy from tree.')
             tree_taxonomy = Taxonomy().read_from_tree(input_tree,
                                                         warnings=False)
-            
+
         gtdb_parent_ranks = Taxonomy().parents(tree_taxonomy)
 
         # read trusted taxa
         trusted_taxa = None
         if trusted_taxa_file:
             trusted_taxa = read_taxa_file(trusted_taxa_file)
-            
+
         # read F-measure for taxa
         fmeasure = None
         if fmeasure_table:
             fmeasure = self.read_fmeasure(fmeasure_table)
 
         # determine taxa to be used for inferring distribution
-        taxa_for_dist_inference = filter_taxa_for_dist_inference(tree, 
-                                                                    taxonomy, 
-                                                                    trusted_taxa, 
-                                                                    min_children, 
+        taxa_for_dist_inference = filter_taxa_for_dist_inference(tree,
+                                                                    taxonomy,
+                                                                    trusted_taxa,
+                                                                    min_children,
                                                                     min_support,
                                                                     fmeasure,
                                                                     min_fmeasure,
@@ -958,10 +962,10 @@ class Outliers(AbstractPlot):
             for node in tree.preorder_node_iter():
                 support, taxon, _auxiliary_info = parse_label(node.label)
                 if taxon:
-                    taxon = taxon.split(';')[-1].strip() # get most specific taxon from compound names 
+                    taxon = taxon.split(';')[-1].strip() # get most specific taxon from compound names
                                                          # (e.g. p__Armatimonadetes; c__Chthonomonadetes)
                     taxa_to_plot.add(taxon)
-            
+
             if False:
                 # HACK FOR NCBI: only plot taxa with >= 2 taxa
                 taxa_to_plot = set()
@@ -972,9 +976,9 @@ class Outliers(AbstractPlot):
                     support, taxon, _auxiliary_info = parse_label(node.label)
                     if not taxon:
                         continue
-                    taxon = taxon.split(';')[-1].strip() # get most specific taxon from compound names 
+                    taxon = taxon.split(';')[-1].strip() # get most specific taxon from compound names
                                                          # (e.g. p__Armatimonadetes; c__Chthonomonadetes)
-                  
+
                     # count number of subordinate children
                     rank_prefix = taxon[0:3]
                     if min_children > 0 and rank_prefix != 's__':
@@ -990,15 +994,15 @@ class Outliers(AbstractPlot):
 
                         if len(subordinate_taxa) < min_children:
                             continue
-                            
+
                     taxa_to_plot.add(taxon)
-            
+
         # highlight taxa
         highlight_taxa = set()
         if highlight_taxa_file:
             for line in open(highlight_taxa_file):
                 highlight_taxa.add(line.strip().split('\t')[0])
-                
+
         # check if a single fixed root should be used
         dist_plot_file = os.path.join(self.output_dir, '{}.png'.format(input_tree_name))
         summary_median_outlier_table = os.path.join(self.output_dir, '{}.tsv'.format(input_tree_name))
@@ -1006,16 +1010,16 @@ class Outliers(AbstractPlot):
                                                 input_tree_name))
         summary_median_rank_file = os.path.join(self.output_dir, '{}.dict'.format(input_tree_name))
         phyla_file = os.path.join(self.output_dir, '{}.phyla.tsv'.format(input_tree_name))
-        
+
         if fixed_root or mblet:
             self.logger.info('Using single fixed rooting for inferring distributions.')
             if not mblet:
                 rel_dists = self.rd_fixed_root(tree, taxa_for_dist_inference)
             else:
                 rel_dists = self.mblet(tree, taxa_for_dist_inference)
-                
+
             # create fixed rooting style tables and plots
-            self._distribution_plot(rel_dists, 
+            self._distribution_plot(rel_dists,
                                         taxa_for_dist_inference,
                                         highlight_polyphyly,
                                         highlight_taxa,
@@ -1025,8 +1029,8 @@ class Outliers(AbstractPlot):
                                         dist_plot_file,
                                         viral)
 
-            self._median_outlier_file(rel_dists, 
-                                        taxa_for_dist_inference, 
+            self._median_outlier_file(rel_dists,
+                                        taxa_for_dist_inference,
                                         gtdb_parent_ranks,
                                         viral,
                                         summary_median_outlier_table,
@@ -1035,13 +1039,13 @@ class Outliers(AbstractPlot):
             # calculate relative distance to taxa
             rd = RelativeDistance()
             rel_dists = rd.rel_dist_to_named_clades(tree)
-            
+
             # restrict to taxa of interest
             if taxa_to_plot:
                 for r in rel_dists:
                     for k in set(rel_dists[r].keys()) - set(taxa_to_plot):
                         del rel_dists[r][k]
-            
+
             # report number of taxa at each rank
             print('')
             print('Rank\tTaxa to Plot\tTaxa for Inference')
@@ -1049,12 +1053,12 @@ class Outliers(AbstractPlot):
                 taxa_for_inference = [x for x in taxa if x in taxa_for_dist_inference]
                 print('%s\t%d\t%d' % (Taxonomy.rank_labels[rank], len(taxa), len(taxa_for_inference)))
             print('')
-        
+
             # *** determine phyla for inferring distribution
             phylum_rel_dists, rel_node_dists = self.median_rd_over_phyla(
-                                                        tree, 
+                                                        tree,
                                                         taxa_for_dist_inference)
-                                                                            
+
             # set edge lengths to median value over all rootings
             tree.seed_node.rel_dist = 0.0
             for n in tree.preorder_node_iter(lambda n: n != tree.seed_node):
@@ -1068,18 +1072,18 @@ class Outliers(AbstractPlot):
                 phylum_dir = os.path.join(self.output_dir, phylum)
                 if not os.path.exists(phylum_dir):
                     os.makedirs(phylum_dir)
-                    
+
                 # restrict to taxa of interest
                 if taxa_to_plot:
                     for r in rel_dists:
                         for k in set(rel_dists[r].keys()) - set(taxa_to_plot):
                             del rel_dists[r][k]
-                    
+
                 # create distribution plot
                 distribution_table = os.path.join(phylum_dir, '%s.rank_distribution.tsv' % phylum)
                 plot_file = os.path.join(phylum_dir, '%s.rank_distribution.png' % phylum)
                 median_rank_file = os.path.join(phylum_dir, '%s.median_red.dict' % phylum)
-                self._distribution_plot(rel_dists, 
+                self._distribution_plot(rel_dists,
                                         taxa_for_dist_inference,
                                         highlight_polyphyly,
                                         highlight_taxa,
@@ -1090,19 +1094,19 @@ class Outliers(AbstractPlot):
                                         viral)
 
                 median_outlier_table = os.path.join(phylum_dir, '%s.median_outlier.tsv' % phylum)
-                self._median_outlier_file(rel_dists, 
-                                            taxa_for_dist_inference, 
+                self._median_outlier_file(rel_dists,
+                                            taxa_for_dist_inference,
                                             gtdb_parent_ranks,
                                             viral,
                                             median_outlier_table,
                                             median_rank_file)
-                                            
+
                 if viral:
                     rev_translate_output_file(distribution_table)
                     rev_translate_output_file(plot_file)
                     rev_translate_output_file(median_outlier_table)
-   
-            self._distribution_summary_plot(phylum_rel_dists, 
+
+            self._distribution_summary_plot(phylum_rel_dists,
                                             taxa_for_dist_inference,
                                             highlight_polyphyly,
                                             highlight_taxa,
@@ -1110,13 +1114,13 @@ class Outliers(AbstractPlot):
                                             fmeasure_mono,
                                             dist_plot_file)
 
-            self._median_summary_outlier_file(phylum_rel_dists, 
-                                                taxa_for_dist_inference, 
-                                                gtdb_parent_ranks, 
-                                                summary_median_outlier_table, 
-                                                summary_median_rank_file, 
+            self._median_summary_outlier_file(phylum_rel_dists,
+                                                taxa_for_dist_inference,
+                                                gtdb_parent_ranks,
+                                                summary_median_outlier_table,
+                                                summary_median_rank_file,
                                                 verbose_table)
-                                                
+
             output_rd_tree = os.path.join(self.output_dir, '{}.red_decorated.tree'.format(input_tree_name))
             self._write_rd_tree(orig_tree, rel_node_dists, output_rd_tree)
 
@@ -1124,22 +1128,22 @@ class Outliers(AbstractPlot):
         self._write_rd(tree, output_rd_file)
 
         output_tree = os.path.join(self.output_dir, '{}.scaled.tree'.format(input_tree_name))
-        tree.write_to_path(output_tree, 
-                            schema='newick', 
-                            suppress_rooting=True, 
+        tree.write_to_path(output_tree,
+                            schema='newick',
+                            suppress_rooting=True,
                             unquoted_underscores=True)
-                            
+
         if viral:
             self.logger.info('Translating output files to viral prefixes.')
             rev_translate_output_file(output_rd_file)
             rev_translate_output_file(output_tree)
             rev_translate_output_file(summary_median_outlier_table)
-            
+
             #rev_translate_output_file(dist_plot_file)
             dist_plot_file_html = dist_plot_file.replace('.png', '.html')
             if os.path.exists(dist_plot_file_html):
                 rev_translate_output_file(dist_plot_file_html)
-            
+
             if os.path.exists(distribution_table):
                 rev_translate_output_file(distribution_table)
             if os.path.exists(summary_median_rank_file):


### PR DESCRIPTION
When writing to the reference tree... possibly a DendroPy issue with the tree input format.

Automatic line formatting went a bit out of control there. Line 834 is the only change:

From:
```
            if n.is_leaf():
                n.taxon.label += "|RED={:.3f}".format(red)
            else:
                n.label += "|RED={:.3f}".format(red)
```

To:
```
            red_str = "|RED={:.3f}".format(red)
            if n.is_leaf():
                n.taxon.label += red_str
            else:
                if n.label:
                    n.label += red_str
                else:
                    n.label = red_str
```

```
Unexpected error: <class 'TypeError'>
Traceback (most recent call last):
  File "/srv/sw/miniconda3/envs/phylorank-0.1.3/bin/phylorank", line 360, in <module>
    parser.parse_options(args)
  File "/srv/sw/miniconda3/envs/phylorank-0.1.3/lib/python3.8/site-packages/phylorank/main.py", line 484, in parse_options
    self.outliers(options)
  File "/srv/sw/miniconda3/envs/phylorank-0.1.3/lib/python3.8/site-packages/phylorank/main.py", line 75, in outliers
    o.run(options.input_tree,
  File "/srv/sw/miniconda3/envs/phylorank-0.1.3/lib/python3.8/site-packages/phylorank/outliers.py", line 1121, in run
    self._write_rd_tree(orig_tree, rel_node_dists, output_rd_tree)
  File "/srv/sw/miniconda3/envs/phylorank-0.1.3/lib/python3.8/site-packages/phylorank/outliers.py", line 834, in _write_rd_tree
    n.label += "|RED={:.3f}".format(red)
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
```